### PR TITLE
Rename write_input_file to dump

### DIFF
--- a/src/cubitpy/cubitpy.py
+++ b/src/cubitpy/cubitpy.py
@@ -329,13 +329,13 @@ class CubitPy(object):
         """Export the mesh."""
         self.cubit.cmd('export mesh "{}" dimension 3 overwrite'.format(path))
 
-    def write_input_file(self, yaml_path):
-        """Create the yaml file an save it in yaml_path.
+    def dump(self, yaml_path):
+        """Create the yaml file and save it in under provided yaml_path.
 
         Args
         ----
         yaml_path: str
-            Path where the input file file will be saved
+            Path where the input file will be saved
         """
 
         # Check if output path exists

--- a/src/tutorial/tutorial.py
+++ b/src/tutorial/tutorial.py
@@ -254,7 +254,7 @@ def cubit_step_by_step_tutorial_cli(
     )
 
     # Write the input file.
-    cubit.write_input_file(input_file_path)
+    cubit.dump(input_file_path)
 
 
 if __name__ == "__main__":

--- a/tests/test_cubitpy.py
+++ b/tests/test_cubitpy.py
@@ -87,7 +87,7 @@ def compare_yaml(cubit, *, name=None, rtol=1.0e-12, atol=1.0e-12):
     # File paths
     ref_file = os.path.join(testing_input, name + ".4C.yaml")
     out_file = os.path.join(testing_temp, name + ".4C.yaml")
-    cubit.write_input_file(out_file)
+    cubit.dump(out_file)
 
     ref_input_file = FourCInput.from_4C_yaml(ref_file)
     out_input_file = FourCInput.from_4C_yaml(out_file)
@@ -559,7 +559,7 @@ def test_block_function():
 
     # Compare the input file created for 4C.
     out_file = os.path.join(testing_temp, "tmp" + ".4C.yaml")
-    cubit.write_input_file(out_file)
+    cubit.dump(out_file)
     compare_yaml(cubit)
 
 


### PR DESCRIPTION
As name indicates the function `write_input_file` is  renamed to `dump`.
Ensures consistency with `meshpy`, see [here](https://github.com/imcs-compsim/meshpy/pull/354) 
