### PR TITLE
Add yaml with exo export

### DIFF
--- a/src/cubitpy/cubit_to_fourc_input.py
+++ b/src/cubitpy/cubit_to_fourc_input.py
@@ -123,23 +123,17 @@ def add_exodus_geometry_section(cubit, input_file, rel_exo_file_path):
         file that contains the mesh.
     """
 
-    # map the problem type to the keyword for the problem specific geometry
-    # section
-    problem_to_geometry_dict = {
-        "Structure": "STRUCTURE GEOMETRY",
-        "Fluid": "FLUID GEOMETRY",
-    }
-
-    # retrieve the problem type
-    problem_type = input_file["PROBLEM TYPE"]["PROBLEMTYPE"]
-    # check if the problem type is supported
-    problem_key = problem_to_geometry_dict.get(problem_type)
-    if problem_key is None:
-        raise ValueError(
-            f"I do not know how to generate a 'GEOMETRY' section for problem type '{problem_type}'. "
-            "Currently supported types are: "
-            f"{', '.join(problem_to_geometry_dict.keys())}."
+    # check which 4C sections are currently defined
+    sections = {data[0].get_four_c_section() for data in cubit.blocks}
+    if not len(sections) == 1:
+        raise RuntimeError(
+            "A geometry section can currently only be generated if a single"
+            "element type is defined in the cubit session, but I found "
+            f"{len(sections)} different element types: {', '.join(sections)}. "
+            "Please include the mesh in the .yaml input file by rerunning "
+            "'cubit.dump()' with the 'mesh_in_exo' argument set to False."
         )
+    problem_key = sections.pop() + " GEOMETRY"
 
     # create the dictionary for the geometry section
     geometry_section_dict = {}

--- a/src/cubitpy/cubit_to_fourc_input.py
+++ b/src/cubitpy/cubit_to_fourc_input.py
@@ -71,17 +71,17 @@ def add_node_sets(cubit, exo, input_file, write_topology_information=True):
         bc_description["E"] = len(node_sets[geometry_type])
 
         if not write_topology_information:
-            # if in compressed format, we will not write the topology
-            # information for the node sets explicitly, but 4C will deduce
-            # them based on the node set ids
+            # when working with external .exo meshes, we do not write the
+            # topology information for the node sets explicitly, since 4C will
+            # deduce them based on the node set ids, when reading the .exo file
             bc_description["ENTITY_TYPE"] = "node_set_id"
 
         input_file[bc_section].append(bc_description)
 
     if write_topology_information:
-        # only add topology information if an uncompressed version is needed
-        # (mostly needed for backward compatibility when the mesh is supposed
-        # to be contained in the .yaml file)
+        # this is the default case: when the mesh is supposed to be contained
+        # in the .yaml file, we have to write the topology information of the
+        # node sets
         name_geometry_tuple = [
             [cupy.geometry.vertex, "DNODE-NODE TOPOLOGY", "DNODE"],
             [cupy.geometry.curve, "DLINE-NODE TOPOLOGY", "DLINE"],

--- a/src/cubitpy/cubit_to_fourc_input.py
+++ b/src/cubitpy/cubit_to_fourc_input.py
@@ -26,11 +26,12 @@ import os
 
 import netCDF4
 import numpy as np
+from fourcipp.legacy_io.inline_dat import to_dat_string
 
 from cubitpy.conf import cupy
 
 
-def add_node_sets(cubit, exo, input_file):
+def add_node_sets(cubit, exo, input_file, write_topology_information=True):
     """Add the node sets contained in the cubit session/exo file to the
     dat_lines."""
 
@@ -69,28 +70,105 @@ def add_node_sets(cubit, exo, input_file):
             input_file[bc_section] = []
         bc_description["E"] = len(node_sets[geometry_type])
 
+        if not write_topology_information:
+            # if in compressed format, we will not write the topology
+            # information for the node sets explicitly, but 4C will deduce
+            # them based on the node set ids
+            bc_description["ENTITY_TYPE"] = "node_set_id"
+
         input_file[bc_section].append(bc_description)
 
-    name_geometry_tuple = [
-        [cupy.geometry.vertex, "DNODE-NODE TOPOLOGY", "DNODE"],
-        [cupy.geometry.curve, "DLINE-NODE TOPOLOGY", "DLINE"],
-        [cupy.geometry.surface, "DSURF-NODE TOPOLOGY", "DSURFACE"],
-        [cupy.geometry.volume, "DVOL-NODE TOPOLOGY", "DVOL"],
-    ]
-    for geo, section_name, set_label in name_geometry_tuple:
-        if len(node_sets[geo]) > 0:
-            input_file[section_name] = []
-            for i_set, node_set in enumerate(node_sets[geo]):
-                node_set.sort()
-                for i_node in node_set:
-                    input_file[section_name].append(
-                        {
-                            "type": "NODE",
-                            "node_id": i_node,
-                            "d_type": set_label,
-                            "d_id": i_set + 1,
-                        }
-                    )
+    if write_topology_information:
+        # only add topology information if an uncompressed version is needed
+        # (mostly needed for backward compatibility when the mesh is supposed
+        # to be contained in the .yaml file)
+        name_geometry_tuple = [
+            [cupy.geometry.vertex, "DNODE-NODE TOPOLOGY", "DNODE"],
+            [cupy.geometry.curve, "DLINE-NODE TOPOLOGY", "DLINE"],
+            [cupy.geometry.surface, "DSURF-NODE TOPOLOGY", "DSURFACE"],
+            [cupy.geometry.volume, "DVOL-NODE TOPOLOGY", "DVOL"],
+        ]
+        for geo, section_name, set_label in name_geometry_tuple:
+            if len(node_sets[geo]) > 0:
+                input_file[section_name] = []
+                for i_set, node_set in enumerate(node_sets[geo]):
+                    node_set.sort()
+                    for i_node in node_set:
+                        input_file[section_name].append(
+                            {
+                                "type": "NODE",
+                                "node_id": i_node,
+                                "d_type": set_label,
+                                "d_id": i_set + 1,
+                            }
+                        )
+
+
+def add_problem_geometry_section(cubit, rel_exo_file_path):
+    """Add the problem specific geometry section to the input file.
+
+    This section contains information about all element blocks as well as the
+    path to the exo file that contains the mesh.
+
+    Args
+    ----
+    cubit: CubitPy
+        The python object for managing the current Cubit session.
+    rel_exo_file_path: str
+        The relative path (as seen from the yaml input file) to the exodus
+        file that contains the mesh.
+    """
+
+    # map the problem type to the keyword for the problem specific geometry
+    # section
+    problem_to_geometry_dict = {
+        "Structure": "STRUCTURE GEOMETRY",
+        "Fluid": "FLUID GEOMETRY",
+    }
+
+    # retrieve the problem type
+    problem_type = cubit.fourc_input["PROBLEM TYPE"]["PROBLEMTYPE"]
+    # check if the problem type is supported
+    problem_key = problem_to_geometry_dict.get(problem_type)
+    if problem_key is None:
+        raise ValueError(
+            f"I do not know how to generate a 'GEOMETRY' section for problem type '{problem_type}'. "
+            "Currently supported types are: "
+            f"{', '.join(problem_to_geometry_dict.keys())}."
+        )
+
+    # create the dictionary for the geometry section
+    geometry_section_dict = {}
+
+    # add the relative path to the exodus file
+    geometry_section_dict["FILE"] = rel_exo_file_path
+    # always show a detailed summary
+    geometry_section_dict["SHOW_INFO"] = "detailed_summary"
+
+    # add the element blocks
+    geometry_section_dict["ELEMENT_BLOCKS"] = []
+    # iterate over all blocks
+    block_ids = cubit.cubit.get_block_id_list()
+    for idx, bid in enumerate(block_ids):
+        # retrieve the data associated with the block
+        data = cubit.blocks[idx]
+        # retrieve the fourc name for the element
+        four_c_element_name = data[0].get_four_c_name()
+        # convert the material data from dict to string because 4C currently does not support a dict here
+        element_data_string = " ".join(
+            f"{key} {value}" for key, value in data[1].items()
+        )
+        # add block id, fourc element name and element data string to the element block dictionary
+        element_block_dict = {
+            "ID": bid,
+            "ELEMENT_NAME": four_c_element_name,
+            "ELEMENT_DATA": element_data_string,
+        }
+        # append the dictionary with the element block information to the element block list
+        geometry_section_dict["ELEMENT_BLOCKS"].append(element_block_dict)
+
+    # at long last, append the geometry section to the input file
+    cubit.fourc_input[problem_key] = geometry_section_dict
 
 
 def get_element_connectivity_list(connectivity):

--- a/src/cubitpy/cubit_to_fourc_input.py
+++ b/src/cubitpy/cubit_to_fourc_input.py
@@ -33,7 +33,7 @@ from cubitpy.conf import cupy
 
 def add_node_sets(cubit, exo, input_file, write_topology_information=True):
     """Add the node sets contained in the cubit session/exo file to the
-    dat_lines."""
+    yaml file."""
 
     # If there are no node sets we can return immediately
     if len(cubit.node_sets) == 0:
@@ -104,8 +104,8 @@ def add_node_sets(cubit, exo, input_file, write_topology_information=True):
                         )
 
 
-def add_problem_geometry_section(cubit, rel_exo_file_path):
-    """Add the problem specific geometry section to the input file.
+def add_exodus_geometry_section(cubit, rel_exo_file_path):
+    """Add the problem specific geometry section to the input file required to directly read the mesh from an exodus file.
 
     This section contains information about all element blocks as well as the
     path to the exo file that contains the mesh.

--- a/src/cubitpy/cubitpy.py
+++ b/src/cubitpy/cubitpy.py
@@ -334,13 +334,13 @@ class CubitPy(object):
         """Export the mesh."""
         self.cubit.cmd('export mesh "{}" dimension 3 overwrite'.format(path))
 
-    def dump(self, path_stem, mesh_in_exo=False):
+    def dump(self, yaml_path, mesh_in_exo=False):
         """Create the yaml file and save it in under provided yaml_path.
 
         Args
         ----
-        path_stem: str
-            Path stem where the input file and the mesh will be saved.
+        yaml_path: str
+            Path where the input file will be saved
         mesh_in_exo: bool
             If True, the mesh will be exported in exodus format and the input file
             will contain a reference to the exodus file. If False, the mesh will
@@ -350,13 +350,17 @@ class CubitPy(object):
         """
 
         # Check if output path exists
-        dat_dir = os.path.dirname(os.path.abspath(path_stem))
+        dat_dir = os.path.dirname(os.path.abspath(yaml_path))
         if not os.path.exists(dat_dir):
             raise ValueError("Path {} does not exist!".format(dat_dir))
 
         if mesh_in_exo:
-            # Create the exodus file
-            exo_path = f"{path_stem}.exo"
+            # Determine the path stem: Strip the '(.4C).yaml' suffix
+            # (if the filename does not contain '.4C' the second call to
+            # 'removesuffix' won't alter the string at all)
+            path_stem = yaml_path.removesuffix(".yaml").removesuffix(".4C")
+            # Export the mesh in exodus format
+            exo_path = path_stem + ".exo"
             self.export_exo(exo_path)
             # parse the exodus file
             exo = netCDF4.Dataset(exo_path)
@@ -370,7 +374,7 @@ class CubitPy(object):
         else:
             input_file = get_input_file_with_mesh(self)
         # Export the input file in YAML format
-        input_file.dump(f"{path_stem}.4C.yaml")
+        input_file.dump(yaml_path)
 
     def group(self, **kwargs):
         """Reference a group in cubit.

--- a/src/cubitpy/cubitpy.py
+++ b/src/cubitpy/cubitpy.py
@@ -350,9 +350,9 @@ class CubitPy(object):
         """
 
         # Check if output path exists
-        dat_dir = os.path.dirname(os.path.abspath(yaml_path))
-        if not os.path.exists(dat_dir):
-            raise ValueError("Path {} does not exist!".format(dat_dir))
+        yaml_dir = os.path.dirname(os.path.abspath(yaml_path))
+        if not os.path.exists(yaml_dir):
+            raise ValueError("Path {} does not exist!".format(yaml_dir))
 
         if mesh_in_exo:
             # Determine the path stem: Strip the '(.4C).yaml' suffix
@@ -369,7 +369,7 @@ class CubitPy(object):
             # Add the node sets
             add_node_sets(self, exo, input_file, write_topology_information=False)
             # Add the problem geometry section
-            rel_exo_path = os.path.relpath(exo_path, start=dat_dir)
+            rel_exo_path = os.path.relpath(exo_path, start=yaml_dir)
             add_exodus_geometry_section(self, input_file, rel_exo_path)
         else:
             input_file = get_input_file_with_mesh(self)

--- a/src/cubitpy/cubitpy.py
+++ b/src/cubitpy/cubitpy.py
@@ -334,7 +334,7 @@ class CubitPy(object):
         """Export the mesh."""
         self.cubit.cmd('export mesh "{}" dimension 3 overwrite'.format(path))
 
-    def dump_w_exo_mesh(self, path_stem):
+    def dump_with_exo_mesh(self, path_stem):
         """Create the 4C yaml input file and export the mesh in exo format.
 
         The path_stem refers to the path where the input file and the mesh

--- a/tests/input-files-ref/test_yaml_with_exo_export.4C.yaml
+++ b/tests/input-files-ref/test_yaml_with_exo_export.4C.yaml
@@ -1,0 +1,54 @@
+PROBLEM SIZE:
+  DIM: 3
+PROBLEM TYPE:
+  PROBLEMTYPE: "Structure"
+DESIGN SURF MORTAR CONTACT CONDITIONS 3D:
+  - InterfaceID: 1
+    Side: "Slave"
+    E: 1
+    ENTITY_TYPE: "node_set_id"
+  - InterfaceID: 1
+    Side: "Master"
+    E: 2
+    ENTITY_TYPE: "node_set_id"
+DESIGN SURF DIRICH CONDITIONS:
+  - NUMDOF: 3
+    ONOFF:
+      - 1
+      - 1
+      - 1
+    VAL:
+      - 0
+      - 0
+      - 0
+    FUNCT:
+      - null
+      - null
+      - null
+    E: 3
+    ENTITY_TYPE: "node_set_id"
+  - NUMDOF: 3
+    ONOFF:
+      - 1
+      - 0
+      - 0
+    VAL:
+      - -1.0
+      - 0.0
+      - 0.0
+    FUNCT:
+      - 1
+      - null
+      - null
+    E: 4
+    ENTITY_TYPE: "node_set_id"
+STRUCTURE GEOMETRY:
+  FILE: "test_yaml_with_exo_export.exo"
+  SHOW_INFO: "detailed_summary"
+  ELEMENT_BLOCKS:
+    - ID: 1
+      ELEMENT_NAME: "SOLID"
+      ELEMENT_DATA: "MAT 1 KINEM nonlinear"
+    - ID: 2
+      ELEMENT_NAME: "SOLID"
+      ELEMENT_DATA: "MAT 2 KINEM nonlinear"

--- a/tests/input-files-ref/test_yaml_with_exo_export_fsi.4C.yaml
+++ b/tests/input-files-ref/test_yaml_with_exo_export_fsi.4C.yaml
@@ -1,0 +1,21 @@
+PROBLEM TYPE:
+  PROBLEMTYPE: "Fluid_Structure_Interaction"
+PROBLEM SIZE:
+  DIM: 3
+STRUCTURAL DYNAMIC:
+  INT_STRATEGY: "Standard"
+  LINEAR_SOLVER: 3
+STRUCTURE GEOMETRY:
+  FILE: "test_yaml_with_exo_export_fsi.exo"
+  SHOW_INFO: "detailed_summary"
+  ELEMENT_BLOCKS:
+    - ID: 1
+      ELEMENT_NAME: "SOLID"
+      ELEMENT_DATA: "MAT 1 KINEM nonlinear TECH eas_full"
+FLUID GEOMETRY:
+  FILE: "test_yaml_with_exo_export_fsi.exo"
+  SHOW_INFO: "detailed_summary"
+  ELEMENT_BLOCKS:
+    - ID: 2
+      ELEMENT_NAME: "FLUID"
+      ELEMENT_DATA: "MAT 2 NA ALE"

--- a/tests/test_cubitpy.py
+++ b/tests/test_cubitpy.py
@@ -113,10 +113,10 @@ def compare_yaml(
     out_file = os.path.join(testing_temp, compare_name + ".4C.yaml")
 
     if mesh_in_exo:
-        out_file_stem = out_file.removesuffix(".4C.yaml")
         # dump the input script with the mesh in exodus format
-        cubit.dump(out_file_stem, mesh_in_exo=True)
+        cubit.dump(out_file, mesh_in_exo=True)
         # make sure the directory also contains the exo mesh
+        out_file_stem = out_file.removesuffix(".4C.yaml")
         assert os.path.exists(f"{out_file_stem}.exo")
     else:
         cubit.dump(out_file)


### PR DESCRIPTION
In this PR, I implemented a method to export the mesh in exo format while dumping the .yaml input file.

When using the new method `dump_with_exo_mesh()`, `cubitpy` will automatically attach the `XYZ GEOMETRY` section to the yaml input file as well as omit the lengthy topology information, which will instead be inferred from the nodesets within 4C when reading in the exo mesh.

To fully enable this feature, I need to know which problems people at the institute are working with, in order to enable the output of the respective "GEOMETRY" section. Currently supported `PROBLEMTYPE`s are 
- `Fluid`
- `Structure`

but more can be added if needed, by extending the `problem_to_geometry_dict` inside the `add_problem_geometry_section()` function.