### PR TITLE
Add functionality to get python objects created during string cmd

### DIFF
--- a/src/cubitpy/cubitpy.py
+++ b/src/cubitpy/cubitpy.py
@@ -28,7 +28,7 @@ import warnings
 
 from fourcipp.fourc_input import FourCInput
 
-from cubitpy.conf import cupy
+from cubitpy.conf import GeometryType, cupy
 from cubitpy.cubit_group import CubitGroup
 from cubitpy.cubit_to_fourc_input import get_input_file_with_mesh
 from cubitpy.cubit_wrapper.cubit_wrapper_host import CubitConnect
@@ -360,6 +360,63 @@ class CubitPy(object):
 
         self.cubit.reset()
         self._default_cubit_variables()
+
+    def cmd_return(
+        self,
+        cmd: str,
+        geometry_type: GeometryType | list[GeometryType],
+        *,
+        simplify_results: bool = True,
+    ):
+        """Run a cubit command and return created geometry objects.
+
+        Args:
+            cmd: The cubit command to run.
+            geometry_type: The geometry type(s) that should be checked for new geometries.
+            simplify_results: If the results shall be simplified.
+
+        Returns:
+            The geometry objects created by the command.
+            If simplify_results is False, a dictionary with the geometry type as key
+            and a list of created objects as value is returned.
+            If simplify_results is True and only one geometry type is
+            requested, a single object is returned. Also, if only one item is created
+            for a geometry, it will not be stored as a list, but as the plain object.
+        """
+
+        if not isinstance(geometry_type, list):
+            geometry_type = [geometry_type]
+
+        # Store the already existing ids for all requested geometry types.
+        geometry_ids_before = {
+            geometry: set(self.get_entities(geometry.get_cubit_string()))
+            for geometry in geometry_type
+        }
+
+        # Run the command.
+        self.cmd(cmd)
+
+        # Get the objects that were created by the command.
+        create_objects = {}
+        for geometry, ids_before in geometry_ids_before.items():
+            ids_after = set(self.get_entities(geometry.get_cubit_string()))
+            ids_new = ids_after - ids_before
+            geometry_objects = self.get_items(geometry, item_ids=ids_new)
+            if simplify_results and len(geometry_objects) < 2:
+                if len(geometry_objects) == 1:
+                    create_objects[geometry] = geometry_objects[0]
+                else:
+                    raise ValueError(
+                        f"The option simplify_results is activated, but for {geometry} "
+                        "no items were created. The command was: {cmd}"
+                    )
+            else:
+                create_objects[geometry] = geometry_objects
+
+        if simplify_results and len(create_objects) == 1:
+            return list(create_objects.values())[0]
+        else:
+            return create_objects
 
     def display_in_cubit(self, labels=[], delay=0.5, testing=False):
         """Save the state to a cubit file and open cubit with that file.

--- a/tests/test_cubitpy.py
+++ b/tests/test_cubitpy.py
@@ -1759,3 +1759,54 @@ def test_extrude_artery_of_aneurysm():
     assert ref_volume == pytest.approx(
         cubit.get_meshed_volume_or_area("volume", [volume.id()]), 1e-5
     )
+
+
+def test_cmd_return():
+    """Test the cmd_return function of CubitPy."""
+
+    cubit = CubitPy()
+
+    center = cubit.cmd_return("create vertex 0 0 0", cupy.geometry.vertex)
+    assert center.get_geometry_type() == cupy.geometry.vertex
+    assert center.id() == 1
+
+    arc_1 = cubit.cmd_return(
+        f"create curve arc center vertex {center.id()} radius 1 full",
+        cupy.geometry.curve,
+    )
+    assert arc_1.get_geometry_type() == cupy.geometry.curve
+    assert arc_1.id() == 1
+
+    center = cubit.cmd_return("create vertex 0.1 0 0", cupy.geometry.vertex)
+    assert center.get_geometry_type() == cupy.geometry.vertex
+    assert center.id() == 3
+
+    arc_2 = cubit.cmd_return(
+        f"create curve arc center vertex {center.id()} radius 2 full",
+        cupy.geometry.curve,
+    )
+    assert arc_2.get_geometry_type() == cupy.geometry.curve
+    assert arc_2.id() == 2
+
+    surface = cubit.cmd_return(
+        f"create surface curve {arc_1.id()} {arc_2.id()}",
+        cupy.geometry.surface,
+    )
+    assert surface.get_geometry_type() == cupy.geometry.surface
+    assert surface.id() == 1
+
+    sweep_geometry = cubit.cmd_return(
+        f"sweep surface {surface.id()} perpendicular distance 2",
+        [
+            cupy.geometry.vertex,
+            cupy.geometry.curve,
+            cupy.geometry.surface,
+            cupy.geometry.volume,
+        ],
+        simplify_results=False,
+    )
+    assert len(sweep_geometry) == 4
+    assert [item.id() for item in sweep_geometry[cupy.geometry.vertex]] == [5, 6]
+    assert [item.id() for item in sweep_geometry[cupy.geometry.curve]] == [3, 4, 5, 6]
+    assert [item.id() for item in sweep_geometry[cupy.geometry.surface]] == [2, 3, 4]
+    assert [item.id() for item in sweep_geometry[cupy.geometry.volume]] == [1]


### PR DESCRIPTION
This PR adds the functionality to get python objects created during string cmd. One can now execute a string command with the wrapper `cmd_return` and this function returns the created geometry objects.