### PR TITLE
Enable running Cubit on a virtual machine via SSH

### DIFF
--- a/src/cubitpy/conf.py
+++ b/src/cubitpy/conf.py
@@ -250,7 +250,7 @@ class CubitOptions(object):
     def get_cubit_interpreter(cls):
         """Get the path to the python interpreter to be used for CubitPy."""
         if cls.is_remote():
-            remote_cubit_root = cupy.get_remote_cubit_path()
+            remote_cubit_root = cls.get_remote_cubit_path()
             return os.path.join(remote_cubit_root, "python3", "python.exe")
         else:
             cubit_root = cls._config["local_config"]["cubit_path"]
@@ -294,7 +294,7 @@ class CubitOptions(object):
 
     @classmethod
     def is_remote(cls) -> bool:
-        """Return the cubpitpy_mode."""
+        """Return True if cubitpy is running in remote mode."""
         return cls.get_config().get("cubitpy_mode") == "remote"
 
     @classmethod

--- a/src/cubitpy/conf.py
+++ b/src/cubitpy/conf.py
@@ -147,6 +147,16 @@ class CubitOptions(object):
             if missing:
                 fail("remote_config is missing required fields: " + ", ".join(missing))
 
+            user = remote_config["user"]
+            host = remote_config["host"]
+            if not isinstance(user, str) or not isinstance(host, str):
+                fail("remote_config 'user' and 'host' must be strings.")
+            if any(c.isspace() or c in "@:/\\" for c in user + host):
+                fail(
+                    "remote_config 'user' and 'host' must not contain whitespace "
+                    "or any of '@ : / \\'."
+                )
+
         if mode == "local":
             if "local_config" not in config:
                 fail("cubitpy_mode='local' requires a 'local_config' section.")

--- a/src/cubitpy/conf.py
+++ b/src/cubitpy/conf.py
@@ -276,6 +276,24 @@ class CubitOptions(object):
             )
         return cls._config.get("cubitpy_mode") == "remote"
 
+    @classmethod
+    def get_remote_user(cls):
+        """Return the remote user."""
+        if cls._config is None:
+            raise RuntimeError(
+                "Config not loaded yet. Call load_cubit_config() first use of is_remote."
+            )
+        return cls._config["remote_config"]["user"]
+
+    @classmethod
+    def get_remote_host(cls):
+        """Return the remote user."""
+        if cls._config is None:
+            raise RuntimeError(
+                "Config not loaded yet. Call load_cubit_config() first use of is_remote."
+            )
+        return cls._config["remote_config"]["host"]
+
 
 # Global object with options for cubitpy.
 cupy = CubitOptions()

--- a/src/cubitpy/conf.py
+++ b/src/cubitpy/conf.py
@@ -333,8 +333,8 @@ class CubitOptions(object):
                             os.add_dll_directory(bin_dir)
                         else:
                             os.environ["PATH"] = bin_dir + os.pathsep + os.environ.get("PATH","")
-                    except Exception:
-                        pass
+                    except Exception as exc:
+                        print("Warning: failed to configure DLL directory or PATH:", exc, file=sys.stderr)
                     for p in (bin_dir, py_dir, site_pkgs):
                         if p and p not in sys.path:
                             sys.path.insert(0, p)

--- a/src/cubitpy/cubit_to_fourc_input.py
+++ b/src/cubitpy/cubit_to_fourc_input.py
@@ -207,7 +207,18 @@ def get_input_file_with_mesh(cubit):
     # Create exodus file
     os.makedirs(cupy.temp_dir, exist_ok=True)
     exo_path = os.path.join(cupy.temp_dir, "cubitpy.exo")
+
+    if cupy.is_remote():
+        exo_path_remote = cubit.temp_dir_remote / "cubitpy.exo"
+        cubit.create_remote_temp_dir(exo_path_remote.parent)
+
     cubit.export_exo(exo_path)
+
+    if cupy.is_remote():
+        cubit.transfer_file_from_remote(exo_path_remote, exo_path)
+
+    if not os.path.isfile(exo_path):
+        raise FileNotFoundError(f"File not found: {exo_path}")
     exo = netCDF4.Dataset(exo_path)
 
     # create a deep copy of the input_file

--- a/src/cubitpy/cubit_to_fourc_input.py
+++ b/src/cubitpy/cubit_to_fourc_input.py
@@ -206,21 +206,13 @@ def get_input_file_with_mesh(cubit):
 
     # Create exodus file
     os.makedirs(cupy.temp_dir, exist_ok=True)
-    exo_path = os.path.join(cupy.temp_dir, "cubitpy.exo")
+    exo_path_local = os.path.join(cupy.temp_dir, "cubitpy.exo")
 
-    if cupy.is_remote():
-        exo_path_remote = cubit.temp_dir_remote / "cubitpy.exo"
-        cubit.create_remote_temp_dir(exo_path_remote.parent)
+    cubit.export_exo(exo_path_local)
 
-    cubit.export_exo(exo_path)
-
-    if cupy.is_remote():
-        cubit.transfer_file_from_remote(exo_path_remote, exo_path)
-
-    if not os.path.isfile(exo_path):
-        raise FileNotFoundError(f"File not found: {exo_path}")
-    exo = netCDF4.Dataset(exo_path)
-
+    if not os.path.isfile(exo_path_local):
+        raise FileNotFoundError(f"File not found: {exo_path_local}")
+    exo = netCDF4.Dataset(exo_path_local)
     # create a deep copy of the input_file
     input_file = cubit.fourc_input.copy()
     # Add the node sets

--- a/src/cubitpy/cubit_wrapper/cubit_wrapper_client.py
+++ b/src/cubitpy/cubit_wrapper/cubit_wrapper_client.py
@@ -270,7 +270,6 @@ while 1:
     elif receive[0] == "write_open_state_journal":
         # receive = ["write_open_state_journal", state_cub, journal_path, active_labels]
         import io
-        import os
         import traceback
 
         state_cub = receive[1]

--- a/src/cubitpy/cubit_wrapper/cubit_wrapper_host.py
+++ b/src/cubitpy/cubit_wrapper/cubit_wrapper_host.py
@@ -100,7 +100,7 @@ class CubitConnect(object):
         else:
             arguments = ["cubit"] + cubit_args
 
-        # Create the a gateway to the remote machine
+        # In remote mode, configure the remote Python environment and send the client code
         if cupy.is_remote():
             util_path = Path(__file__).with_name("cubit_wrapper_utility.py")
             util_code = util_path.read_text(encoding="utf-8")

--- a/src/cubitpy/cubit_wrapper/cubit_wrapper_host.py
+++ b/src/cubitpy/cubit_wrapper/cubit_wrapper_host.py
@@ -69,7 +69,10 @@ class CubitConnect(object):
 
         # Remote mode – run cubit on a remote machine via SSH
         if cupy.is_remote():
-            ssh_user, ssh_host, remote_cubit_root = cupy.get_cubit_remote_config()
+            ssh_user = cupy.get_remote_user()
+            ssh_host = cupy.get_remote_host()
+            remote_cubit_root = cupy.get_remote_cubit_path()
+
             win_py = os.path.join(remote_cubit_root, "python3", "python.exe")
 
             # make gateway

--- a/src/cubitpy/cubitpy.py
+++ b/src/cubitpy/cubitpy.py
@@ -55,21 +55,32 @@ def convert_to_remote_path(self, path: str) -> PureWindowsPath:
 
 def run_ssh(ssh_base, label, cmd, timeout=25, tolerate_fail=False):
     """Run an SSH command and print the output."""
-    print(f"\n[{label}]")
+    print(f"\n[SSH:{label}]")
     print("$", " ".join(shlex.quote(x) for x in (ssh_base + [cmd])))
+
     res = subprocess.run(
-        ssh_base + [cmd], capture_output=True, text=False, timeout=timeout
+        ssh_base + [cmd],
+        capture_output=True,
+        text=True,
+        timeout=timeout,
     )  # nosec B603
-    out = res.stdout.decode("utf-8", "replace").rstrip()
-    err = res.stderr.decode("utf-8", "replace").rstrip()
+
+    out = res.stdout.rstrip()
+    err = res.stderr.rstrip()
+
     if out:
+        print("[STDOUT]")
         print(out)
     if err:
+        print("[STDERR]")
         print(err)
+
     ok = (res.returncode == 0) or tolerate_fail
-    print(f"-> exit: {res.returncode} ({'ok' if ok else 'fail'})")
+    print(f"[SSH] exit={res.returncode} status={'ok' if ok else 'fail'}")
+
     if not ok:
         raise RuntimeError(f"SSH command failed: {cmd}")
+
     return ok
 
 
@@ -118,9 +129,7 @@ class CubitPy(object):
             if (
                 self.get_remote_os().lower().startswith("windows")
             ):  # This can not be moved to cupy
-                self.temp_dir_remote = PureWindowsPath("C:") / PureWindowsPath(
-                    cupy.temp_dir
-                )
+                self.temp_dir_remote = PureWindowsPath("C:/", cupy.temp_dir)
                 print(f"[Remote temp. dir] {self.temp_dir_remote}")
             else:
                 raise NotImplementedError("Remote non-Windows OS not tested")

--- a/src/cubitpy/cubitpy.py
+++ b/src/cubitpy/cubitpy.py
@@ -21,11 +21,13 @@
 # THE SOFTWARE.
 """Implements a class that helps create meshes with cubit."""
 
+import datetime
 import os
+import shlex
 import subprocess  # nosec B404
 import time
 import warnings
-from pathlib import Path
+from pathlib import Path, PureWindowsPath
 
 import netCDF4
 from fourcipp.fourc_input import FourCInput
@@ -38,6 +40,37 @@ from cubitpy.cubit_to_fourc_input import (
     get_input_file_with_mesh,
 )
 from cubitpy.cubit_wrapper.cubit_wrapper_host import CubitConnect
+
+
+def convert_to_remote_path(self, path: str) -> PureWindowsPath:
+    """Convert a local path to a remote path."""
+    if self.get_remote_os().lower().startswith("windows"):
+        path_remote = PureWindowsPath(path)
+        print(f"[PATH CONVERTED TO] {path_remote}")
+        self.create_remote_temp_dir(str(path_remote.parent))
+        return path_remote
+    else:
+        raise NotImplementedError("Remote non-Windows OS not supported")
+
+
+def run_ssh(ssh_base, label, cmd, timeout=25, tolerate_fail=False):
+    """Run an SSH command and print the output."""
+    print(f"\n[{label}]")
+    print("$", " ".join(shlex.quote(x) for x in (ssh_base + [cmd])))
+    res = subprocess.run(
+        ssh_base + [cmd], capture_output=True, text=False, timeout=timeout
+    )  # nosec B603
+    out = res.stdout.decode("utf-8", "replace").rstrip()
+    err = res.stderr.decode("utf-8", "replace").rstrip()
+    if out:
+        print(out)
+    if err:
+        print(err)
+    ok = (res.returncode == 0) or tolerate_fail
+    print(f"-> exit: {res.returncode} ({'ok' if ok else 'fail'})")
+    if not ok:
+        raise RuntimeError(f"SSH command failed: {cmd}")
+    return ok
 
 
 def _get_and_check_ids(name, container, id_list, given_id):
@@ -74,19 +107,29 @@ class CubitPy(object):
         kwargs:
             Arguments passed on to the creation of the python wrapper
         """
+        # FixMe: cubit_exe
+        cubit_exe = None
         # load config
         cupy.load_cubit_config(cubit_config_path)
 
         # Set the "real" cubit object
         self.cubit = CubitConnect(**kwargs).cubit
 
+        # Set paths
+        if not cupy.is_remote():
+            if cubit_exe is None:
+                cubit_exe = cupy.get_cubit_exe_path()
+            self.cubit_exe = cubit_exe
+
         # Set remote paths
         if cupy.is_remote():
-            raise NotImplementedError(
-                "Remote cubit connections are not yet supported in CubitPy."
-            )
-        else:
-            self.cubit_exe = cupy.get_cubit_exe_path()
+            if self.get_remote_os().lower().startswith("windows"):
+                self.temp_dir_remote = PureWindowsPath("C:") / PureWindowsPath(
+                    cupy.temp_dir
+                )
+                print(f"[REMOTE TEMP DIR] {self.temp_dir_remote}")
+            else:
+                raise NotImplementedError("Remote non-Windows OS not tested")
 
         # Reset cubit
         self.cubit.cmd("reset")
@@ -382,7 +425,8 @@ class CubitPy(object):
 
         # Check if output path exists
         yaml_dir = os.path.dirname(os.path.abspath(yaml_path))
-        if not os.path.exists(yaml_dir):
+        print(f"[CubitPy.dump] Writing YAML to {yaml_path}")
+        if not os.path.exists(yaml_dir) and not cupy.is_remote():
             raise ValueError("Path {} does not exist!".format(yaml_dir))
 
         if mesh_in_exo:
@@ -529,6 +573,10 @@ class CubitPy(object):
             journal and command will re returned.
         """
 
+        if cupy.is_remote():
+            self.display_in_cubit_remote(labels, delay, testing)
+            return
+
         # Export the cubit state. After the export, we wait, to ensure that the
         # write operation finished, and the state file can be opened cleanly
         # (in some cases the creation of the state file takes to long and in
@@ -591,3 +639,136 @@ class CubitPy(object):
             )
         else:
             return journal_path
+
+    def create_remote_temp_dir(self, path) -> str:
+        """Create and return remote temp directory."""
+        # Ensure path is a string
+        if not isinstance(path, str):
+            path = str(path)
+
+        print(f"[Cubit.create_remote_dir] Creating remote temp directory...{path}")
+        resp = self.cubit.cubit_connect.send_and_return(
+            ["create_remote_temp_dir", path]
+        )
+        if not isinstance(resp, str):
+            raise RuntimeError(f"Remote temp-dir creation failed: {resp!r}")
+        return resp
+
+    def get_remote_os(self):
+        """Return the remote system name."""
+        resp = self.cubit.cubit_connect.send_and_return(["get_remote_os"])
+        if not isinstance(resp, str):
+            raise RuntimeError(f"Remote OS query failed: {resp!r}")
+        return resp
+
+    def transfer_file_from_remote(
+        self, remote_path: PureWindowsPath, local_path: str
+    ) -> str:
+        """Copy a file from the remote machine to the local host."""
+        ssh_user = cupy.get_remote_user()
+        ssh_host = cupy.get_remote_host()
+        print(f"[REMOTE PATH] from export exo {remote_path}")
+        # Ensure the path has a drive letter (scp requires C:/… - cubit does not)
+        if not remote_path.drive:
+            remote_path = PureWindowsPath("C:", *remote_path.parts)
+
+        print(f"[REMOTE PATH] with C {remote_path}")
+        # is required
+        remote_for_scp = remote_path.as_posix()
+
+        print(f"[REMOTE PATH] after posix{remote_path}")
+        cmd = ["scp", f"{ssh_user}@{ssh_host}:{remote_for_scp}", local_path]
+        print(f"[transfer] Running: {' '.join(cmd)}")
+
+        try:
+            subprocess.check_output(cmd, stderr=subprocess.STDOUT)  # nosec B603
+        except subprocess.CalledProcessError as e:
+            output = e.output.decode("utf-8", "replace")
+            raise RuntimeError(
+                "Failed to copy remote file:\n"
+                f"  remote: {remote_for_scp}\n"
+                f"  local : {local_path}\n"
+                f"  cmd   : {' '.join(cmd)}\n"
+                f"  error : {output}"
+            ) from e
+
+        print(f"[transfer] Copy OK: {remote_for_scp} → {local_path}")
+        return local_path
+
+    def display_in_cubit_remote(self, labels=None, delay=0.5, testing=False):
+        """Display the current state in Cubit on a remote Windows machine."""
+
+        # Ensure remote temp directory exists
+        self.create_remote_temp_dir(self.temp_dir_remote)
+
+        if labels is None:
+            labels = []
+
+        # Remote configuration and paths
+        ssh_user, ssh_host, win_cubit_root = cupy.get_cubit_remote_config()
+
+        WIN_CUBIT_EXE = rf"{win_cubit_root}\coreform_cubit.exe"
+        STATE_CUB = rf"{self.temp_dir_remote}\ssh_test.cub5"
+        JOURNAL = rf"{self.temp_dir_remote}\open_state.jou"
+        TASK_NAME = "Cubit_Show_Once"
+        SSH = ["ssh", f"{ssh_user}@{ssh_host}"]
+        print(f"[USE] {self.temp_dir_remote}")
+        print(f"[REMOTE TEMP DIR] {self.temp_dir_remote}")
+        print(f"STATE_CUB: {STATE_CUB}")
+        print(f"JOURNAL: {JOURNAL}")
+        # Basic SSH check
+        run_ssh(SSH, "echo", "cmd /c echo OK")
+
+        # Export state to Windows filesystem
+        self.export_cub(STATE_CUB)
+        time.sleep(delay)
+
+        # Resolve active label names
+        cubit_names = [label.get_cubit_string() for label in labels]
+
+        # Create journal file on the Windows side
+        resp = self.cubit.cubit_connect.send_and_return(
+            ["write_open_state_journal", STATE_CUB, JOURNAL, cubit_names]
+        )
+        if not isinstance(resp, dict) or resp.get("status") != "ok":
+            raise RuntimeError(f"Failed to write journal on remote client: {resp!r}")
+
+        if testing:
+            return {
+                "state_cub": STATE_CUB,
+                "journal": JOURNAL,
+                "exe": WIN_CUBIT_EXE,
+                "task": TASK_NAME,
+                "journal_resp": resp,
+            }
+
+        # Remove any old scheduled task
+        run_ssh(
+            SSH,
+            "delete old task",
+            rf"schtasks /Delete /TN {TASK_NAME} /F",
+            tolerate_fail=True,
+        )
+
+        # Create a scheduled task that launches Cubit in the interactive session
+        st = (datetime.datetime.now() + datetime.timedelta(minutes=1)).strftime("%H:%M")
+        create = (
+            rf"schtasks /Create /TN {TASK_NAME} /SC ONCE /ST {st} /TR "
+            rf'"\"{WIN_CUBIT_EXE}\" -nojournal -information Off -input \"{JOURNAL}\"" '
+            rf"/RL HIGHEST /IT /RU {ssh_user} /F"
+        )
+        run_ssh(SSH, "create task", create)
+
+        # Run the task immediately
+        run_ssh(
+            SSH,
+            "run task",
+            rf"schtasks /Run /TN {TASK_NAME}",
+            tolerate_fail=True,
+        )
+
+        print("Remote Cubit startup requested:")
+        print(f"  DB : {STATE_CUB}")
+        print(f"  JOU: {JOURNAL}")
+        print(f"  EXE: {WIN_CUBIT_EXE}")
+        print(f"  Task: {TASK_NAME}")

--- a/src/cubitpy/cubitpy.py
+++ b/src/cubitpy/cubitpy.py
@@ -671,46 +671,45 @@ class CubitPy(object):
             raise RuntimeError(f"Remote OS query failed: {resp!r}")
         return resp
 
+    def transfer_file_from_remote(
+        self, remote_path: PureWindowsPath, local_path: str
+    ) -> str:
+        """Copy a file from the remote machine to the local host."""
+        ssh_user = cupy.get_remote_user()
+        ssh_host = cupy.get_remote_host()
 
-def transfer_file_from_remote(
-    self, remote_path: PureWindowsPath, local_path: str
-) -> str:
-    """Copy a file from the remote machine to the local host."""
-    ssh_user = cupy.get_remote_user()
-    ssh_host = cupy.get_remote_host()
+        print("\n[transfer] Starting remote file transfer")
+        print(f"[transfer] Remote user/host : {ssh_user}@{ssh_host}")
+        print(f"[transfer] Original path    : {remote_path}")
 
-    print("\n[transfer] Starting remote file transfer")
-    print(f"[transfer] Remote user/host : {ssh_user}@{ssh_host}")
-    print(f"[transfer] Original path    : {remote_path}")
+        # Ensure the path has a drive letter (scp requires C:/… - cubit does not)
+        if not remote_path.drive:
+            remote_path = PureWindowsPath("C:", *remote_path.parts)
+            print(f"[transfer] Drive letter added: {remote_path}")
 
-    # Ensure the path has a drive letter (scp requires C:/… - cubit does not)
-    if not remote_path.drive:
-        remote_path = PureWindowsPath("C:", *remote_path.parts)
-        print(f"[transfer] Drive letter added: {remote_path}")
+        # Required for scp
+        remote_for_scp = remote_path.as_posix()
 
-    # Required for scp
-    remote_for_scp = remote_path.as_posix()
+        print(f"[transfer] SCP path         : {remote_for_scp}")
+        print(f"[transfer] Local target     : {local_path}")
 
-    print(f"[transfer] SCP path         : {remote_for_scp}")
-    print(f"[transfer] Local target     : {local_path}")
+        cmd = ["scp", f"{ssh_user}@{ssh_host}:{remote_for_scp}", local_path]
+        print(f"[transfer] Command          : {' '.join(cmd)}")
 
-    cmd = ["scp", f"{ssh_user}@{ssh_host}:{remote_for_scp}", local_path]
-    print(f"[transfer] Command          : {' '.join(cmd)}")
+        try:
+            subprocess.check_output(cmd, stderr=subprocess.STDOUT)  # nosec B603
+        except subprocess.CalledProcessError as e:
+            output = e.output.decode("utf-8", "replace")
+            raise RuntimeError(
+                "[transfer] FAILED\n"
+                f"  remote : {remote_for_scp}\n"
+                f"  local  : {local_path}\n"
+                f"  cmd    : {' '.join(cmd)}\n"
+                f"  error  : {output}"
+            ) from e
 
-    try:
-        subprocess.check_output(cmd, stderr=subprocess.STDOUT)  # nosec B603
-    except subprocess.CalledProcessError as e:
-        output = e.output.decode("utf-8", "replace")
-        raise RuntimeError(
-            "[transfer] FAILED\n"
-            f"  remote : {remote_for_scp}\n"
-            f"  local  : {local_path}\n"
-            f"  cmd    : {' '.join(cmd)}\n"
-            f"  error  : {output}"
-        ) from e
-
-    print(f"[transfer] SUCCESS → {remote_for_scp} → {local_path}\n")
-    return local_path
+        print(f"[transfer] SUCCESS → {remote_for_scp} → {local_path}\n")
+        return local_path
 
     def display_in_cubit_remote(self, labels=None, delay=1.0, testing=False):
         """Display the current state in Cubit on a remote Windows machine."""

--- a/src/cubitpy/cubitpy.py
+++ b/src/cubitpy/cubitpy.py
@@ -42,17 +42,6 @@ from cubitpy.cubit_to_fourc_input import (
 from cubitpy.cubit_wrapper.cubit_wrapper_host import CubitConnect
 
 
-def convert_to_remote_path(self, path: str) -> PureWindowsPath:
-    """Convert a local path to a remote path."""
-    if self.get_remote_os().lower().startswith("windows"):
-        path_remote = PureWindowsPath(path)
-        print(f"[PATH CONVERTED TO] {path_remote}")
-        self.create_remote_temp_dir(str(path_remote.parent))
-        return path_remote
-    else:
-        raise NotImplementedError("Remote non-Windows OS not supported")
-
-
 def run_ssh(ssh_base, label, cmd, timeout=25, tolerate_fail=False):
     """Run an SSH command and print the output."""
     print(f"\n[SSH:{label}]")
@@ -135,8 +124,7 @@ class CubitPy(object):
                 raise NotImplementedError("Remote non-Windows OS not tested")
 
         else:
-            cubit_exe = cupy.get_cubit_exe_path()
-            self.cubit_exe = cubit_exe
+            self.cubit_exe = cupy.get_cubit_exe_path()
 
         # Reset cubit
         self.cubit.cmd("reset")
@@ -593,6 +581,7 @@ class CubitPy(object):
         """
 
         if cupy.is_remote():
+            delay += 0.5
             self.display_in_cubit_remote(labels, delay, testing)
             return
 
@@ -696,7 +685,7 @@ class CubitPy(object):
             remote_path = PureWindowsPath("C:", *remote_path.parts)
             print(f"[transfer] Drive letter added: {remote_path}")
 
-        # Required for scp
+        # Convert the Windows-style path to a POSIX-style string for use with scp
         remote_for_scp = remote_path.as_posix()
 
         print(f"[transfer] SCP path         : {remote_for_scp}")

--- a/src/cubitpy/cubitpy.py
+++ b/src/cubitpy/cubitpy.py
@@ -705,7 +705,9 @@ class CubitPy(object):
             labels = []
 
         # Remote configuration and paths
-        ssh_user, ssh_host, win_cubit_root = cupy.get_cubit_remote_config()
+        ssh_user = cupy.get_remote_user()
+        ssh_host = cupy.get_remote_host()
+        win_cubit_root = cupy.get_remote_cubit_patht()
 
         WIN_CUBIT_EXE = rf"{win_cubit_root}\coreform_cubit.exe"
         STATE_CUB = rf"{self.temp_dir_remote}\ssh_test.cub5"


### PR DESCRIPTION
This Draft adds first support for executing and visualizing **Coreform Cubit** run inside a Windows VM.
Tested with Parallels/Windows11 

The following tests are currently failing:

- ~~`test_cubitpy.py::test_element_types_tet`  
  **AssertionError:** Inputs are not equal~~  

- ~~`test_cubitpy.py::test_extrude_mesh_function`  
  **AssertionError:** Numeric mismatch (0.6917… != expected)~~  

- ~~`test_cubitpy.py::test_extrude_mesh_function_average_normals_for_cylinder_and_sphere`~~  

- ~~`test_cubitpy.py::test_get_id_functions`  
  **AssertionError:** `[2] == [1, 2]` failed~~  

- `test_cubitpy.py::test_display_in_cubit`  
  **TypeError:** expected `str`, got `bytes`

- `test_cubitpy.py::test_import_fluent_geometry`  
  **AssertionError:** Expected 1, got 0

- ~~`test_cubitpy.py::test_cmd_return`  
  **AssertionError:** 1 != 0~~  

- ~~`test_fw.py::test_debug_env`  
  **AssertionError:** False is not True~~  

- ~~`test_tutorial.py::test_cubit_tutorial`  
  **AssertionError:** Inputs are not equal~~
