### PR TITLE
Add configurable Cubit error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ remote_config:
   host: "hostname"
   platform: "windows"
   cubit_path: "C:\\Coreform_Cubit_2025.8"
+on_cubit_error: "raise"  # optional: "raise" (default), "warn" or "ignore"
 ```
 To run CubitPy one can either provide the configuration file then initializing CubitPy, or set an environment variable with the path to the configuration file.
 ```bash

--- a/src/cubitpy/conf.py
+++ b/src/cubitpy/conf.py
@@ -108,6 +108,17 @@ class CubitOptions(object):
         # Tolerance for geometry.
         self.eps_pos = 1e-10
 
+    @property
+    def on_cubit_error(self) -> str:
+        """How to react when a cubit command reports an error.
+
+        One of "raise" (default, raise a RuntimeError), "warn" (emit a
+        CubitPyWarning and continue) or "ignore" (silently continue),
+        set via the optional top-level 'on_cubit_error' key in the
+        config file.
+        """
+        return self._get_config().get("on_cubit_error", "raise")
+
     def _get_config(self) -> Dict[str, Any]:
         """Get the config dict or raise an error if not loaded."""
         if self._config is None:
@@ -134,6 +145,8 @@ class CubitOptions(object):
             "\n"
             "local_config:\n"
             '  cubit_path: "<local_cubit_install_path>"\n'
+            "\n"
+            'on_cubit_error: "raise"  # optional: "raise" (default), "warn" or "ignore"\n'
             "----------------------------------------\n"
             "- If mode = 'remote': remote_config MUST exist and contain user, host, platform, cubit_path.\n"
             "- If mode = 'local' : local_config MUST exist and contain cubit_path.\n"
@@ -152,6 +165,12 @@ class CubitOptions(object):
         mode = config["cubitpy_mode"]
         if mode not in ("remote", "local"):
             fail(f"Invalid cubitpy_mode '{mode}'. Expected 'remote' or 'local'.")
+
+        if config.get("on_cubit_error", "raise") not in ("raise", "warn", "ignore"):
+            fail(
+                f"Invalid on_cubit_error '{config['on_cubit_error']}'. "
+                "Expected 'raise', 'warn' or 'ignore'."
+            )
 
         if mode == "remote":
             if "remote_config" not in config:

--- a/src/cubitpy/cubit_wrapper/cubit_wrapper_host.py
+++ b/src/cubitpy/cubit_wrapper/cubit_wrapper_host.py
@@ -129,9 +129,16 @@ class CubitConnect(object):
                         stacklevel=3,
                     )
                 if len(return_value["errors"]) > 0:
-                    raise RuntimeError(
-                        get_log_string(return_value["errors"], "error(s)")
-                    )
+                    error_string = get_log_string(return_value["errors"], "error(s)")
+                    if cupy.on_cubit_error == "raise":
+                        raise RuntimeError(error_string)
+                    elif cupy.on_cubit_error == "warn":
+                        warnings.warn(
+                            error_string,
+                            category=CubitPyWarning,
+                            stacklevel=3,
+                        )
+                    # "ignore": silently continue
                 return return_value["return_value"]
             else:
                 return return_value

--- a/tests/test_cubitpy.py
+++ b/tests/test_cubitpy.py
@@ -2561,3 +2561,34 @@ def test_exodus_to_dict():
     }
 
     compare_nested_dicts_or_lists(exo_dict, reference_exo_dict)
+
+
+def test_on_cubit_error_config(tmp_path):
+    """The optional 'on_cubit_error' config key sets the error reaction."""
+
+    def write_config(extra=""):
+        """Write a minimal remote config, optionally with an extra line."""
+        path = tmp_path / "cubitpy_config.yaml"
+        path.write_text(
+            'cubitpy_mode: "remote"\n'
+            f"{extra}"
+            "remote_config:\n"
+            '  user: "user"\n'
+            '  host: "host"\n'
+            '  platform: "linux"\n'
+            '  cubit_path: "/cubit"\n'
+        )
+        return path
+
+    saved_config = cupy._config
+    try:
+        cupy.load_cubit_config(write_config())
+        assert cupy.on_cubit_error == "raise"  # default when the key is absent
+
+        cupy.load_cubit_config(write_config('on_cubit_error: "warn"\n'))
+        assert cupy.on_cubit_error == "warn"
+
+        with pytest.raises(RuntimeError, match="Invalid on_cubit_error"):
+            cupy.load_cubit_config(write_config('on_cubit_error: "bogus"\n'))
+    finally:
+        cupy._config = saved_config


### PR DESCRIPTION
## Description

This PR adds an optional top-level `on_cubit_error` configuration option to control how CubitPy handles reported Cubit command errors.

Available options:
- `raise` (default): raise a `RuntimeError` (existing behavior)
- `warn`: emit a `CubitPyWarning` and continue
- `ignore`: silently continue

The option is validated when the configuration is loaded, applied where Cubit command errors are handled, documented in the README configuration example, and covered by a unit test.

Since the default is `raise`, this change is fully backward compatible.